### PR TITLE
Correct autopopulate command add-home-links syntax

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -104,7 +104,7 @@ Installing wagtailmenus
 
     .. code-block:: console
 
-        python manage.py autopopulate_main_menus --add-home-links=True
+        python manage.py autopopulate_main_menus --add-home-links
 
     This would create a main menu with the following items:
 


### PR DESCRIPTION
When I tried to run the command as written I got an error; this syntax worked