### PR TITLE
Fix show_menu_heading for default flat menus

### DIFF
--- a/wagtailmenus/templates/menus/flat_menu.html
+++ b/wagtailmenus/templates/menus/flat_menu.html
@@ -1,6 +1,6 @@
 {% load menu_tags %}
 <div class="flat-menu {{ menu_handle }} {% if menu_heading %}with_heading{% else %}no_heading{% endif %}">
-    {% if menu_heading %}<h4>{{ menu_heading|safe }}</h4>{% endif %}
+    {% if show_menu_heading and menu_heading %}<h4>{{ menu_heading|safe }}</h4>{% endif %}
     {% if menu_items %}
     <ul>
         {% for item in menu_items %}


### PR DESCRIPTION
### Current Behavior
The default template does not currently honor the `show_menu_heading` parameter.

### Desired Behavior
The `show_menu_heading` setting works as documented.

### Alternative Approaches Considered
- Suppress `menu_heading` for templates if `show_menu_heading = True`. This is more in line with defensive programming practices, but it could break existing implementations relying on the buggy behavior. 