### PR TITLE
Set a default autofield type in application configuration

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@
 * Philipp Bosch (philippbosch) (A Color Bright)
 * Oktay Altay (OktayAltay)
 * Dan Bentley (danbentley)
-* Arkadiusz Michał Ryś (ArkadiuszMichalRys)
+* Arkadiusz Michał Ryś (arrys)
 * Sekani Tembo (Method Softworks)
 
 ## Translators

--- a/wagtailmenus/apps.py
+++ b/wagtailmenus/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class WagtailMenusConfig(AppConfig):
     name = 'wagtailmenus'
     verbose_name = 'WagtailMenus'
+    default_auto_field = 'django.db.models.BigAutoField'


### PR DESCRIPTION
Django 3.2 added a change  which causes a warning to be shown for any application which does not set the default_auto_field attribute.

[The release notes for Django 3.2](https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys) cover this in more detail.

This pull request aims to fix this for wagtailmenus by setting the default to BigAutoField.
BigAutoField will cause a migration. It is however, the default for new project started with Django 3.2 and up.