### PR TITLE
Recipes plus Django 4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 * Added support for Wagtail 2.10 (no code changes necessary)
+* Added support for Django 4.0
 * Updated menu classes to better support cases where 'request' and 'site' are not available in the context
 
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@
 * Dan Bentley (danbentley)
 * Arkadiusz Michał Ryś (ArkadiuszMichalRys)
 * Sekani Tembo (Method Softworks)
+* Fernando Cordeiro (MrCordeiro)
 
 ## Translators
 

--- a/docs/source/advanced_topics/custom_menu_classes.rst
+++ b/docs/source/advanced_topics/custom_menu_classes.rst
@@ -31,7 +31,7 @@ If you're happy with the default ``MainMenu`` model, but wish customise the menu
         # appname/models.py
 
         from django.db import models
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
         from wagtail.images import get_image_model_string
         from wagtail.images.edit_handlers import ImageChooserPanel
@@ -110,7 +110,7 @@ If you also need to override the ``MainMenu`` model, that's possible too. But, b
 
         from django.db import models
         from django.utils import translation
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from django.utils import timezone
         from modelcluster.fields import ParentalKey
         from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
@@ -206,7 +206,7 @@ If you're happy with the default ``FlatMenu`` model, but wish customise the menu
         # apname/models.py
 
         from django.db import models
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
         from wagtail.images import get_image_model_string
         from wagtail.images.edit_handlers import ImageChooserPanel
@@ -287,7 +287,7 @@ If you also need to override the ``FlatMenu`` model, that's possible too. But, b
 
         from django.db import models
         from django.utils import translation
-        from django.utils.translation import ugettext_lazy as _
+        from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
         from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
         from wagtailmenus.conf import settings
@@ -436,7 +436,7 @@ The class ``wagtailmenus.models.menus.SectionMenu`` is used by default, but you 
 
     # mysite/appname/models.py
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
     from wagtail.core.models import Page
     from wagtailmenus.models import SectionMenu
 
@@ -471,7 +471,7 @@ The class ``wagtailmenus.models.menus.ChildrenMenu`` is used by default, but you
 
     # appname/menus.py
 
-    from django.utils.translation import ugettext_lazy as _
+    from django.utils.translation import gettext_lazy as _
     from wagtail.core.models import Page
     from wagtailmenus.models import ChildrenMenu
 

--- a/docs/source/advanced_topics/index.rst
+++ b/docs/source/advanced_topics/index.rst
@@ -7,3 +7,4 @@ Advanced topics
 
     hooks
     custom_menu_classes
+    recipes

--- a/docs/source/advanced_topics/recipes.rst
+++ b/docs/source/advanced_topics/recipes.rst
@@ -1,0 +1,86 @@
+
+.. _recipes:
+
+===========================
+Recipes
+===========================
+
+.. contents::
+    :local:
+    :depth: 2
+
+
+.. _i18n:
+
+Internationalization for main menus
+===================================
+
+While wagtailmenus doesn't provide any internationalization support out-of-the-box, you can create your own custom menu with internationalization support.
+
+The example below is useful if your are using either Wagtail's native internationalization support or a package like `wagtail-localize <https://github.com/wagtail/wagtail-localize>`_, where language-specific trees are being automatically synced.
+
+.. code-block:: python
+    # models.py
+    from modelcluster.fields import ParentalKey
+    from django.db import models
+    from wagtail.core.models import Page
+    from wagtailmenus.conf import settings as wagtail_settings
+    from wagtailmenus.models import AbstractMainMenu, AbstractMainMenuItem
+
+
+    class LocalizedMainMenu(AbstractMainMenu):
+    """A Menu that shows the the localized version of the menu items"""
+
+        def get_pages_for_display(self):
+            """Returns a queryset of all pages needed to render the menu."""
+            if hasattr(self, "_raw_menu_items"):
+                # get_top_level_items() may have set this
+                menu_items = self._raw_menu_items
+            else:
+                menu_items = self.get_base_menuitem_queryset()
+
+            # Start with an empty queryset, and expand as needed
+            queryset = Page.objects.none()
+
+            for item in (item for item in menu_items if item.link_page):
+                if item.link_page.localized:
+                    item.link_page = item.link_page.localized
+
+                if (
+                    item.allow_subnav
+                    and item.link_page.depth >= wagtail_settings.SECTION_ROOT_DEPTH
+                ):
+                    # If menu item have subpages, add those to the queryset
+                    queryset = queryset | Page.objects.filter(
+                        path__startswith=item.link_page.path,
+                        depth__lt=item.link_page.depth + self.max_levels,
+                    )
+                else:
+                    queryset = queryset | Page.objects.filter(id=item.link_page_id)
+
+            # Filter out pages unsutable display
+            queryset = self.get_base_page_queryset() & queryset
+
+            # Always return 'specific' page instances
+            return queryset.specific()
+
+
+    class LocalizedMainMenuItem(AbstractMainMenuItem):
+        menu = ParentalKey(
+            LocalizedMainMenu,
+            on_delete=models.CASCADE,
+            related_name=wagtail_settings.MAIN_MENU_ITEMS_RELATED_NAME,
+        )
+
+        def __init__(self, *args, **kwargs):
+            """
+            This makes the menu work seamlessly with multi-language entirely:
+            - In the admin you only add the pages once per language, but the
+            menu also appears even if you are visiting the page that is in
+            another language.
+            - The menu item's text is in the current language.
+            - The menu item's link point to the right language.
+            """
+            super().__init__(*args, **kwargs)
+            if self.link_page and self.link_page.localized:
+                self.link_page = self.link_page.localized

--- a/docs/source/releases/3.1.rst
+++ b/docs/source/releases/3.1.rst
@@ -16,13 +16,13 @@ Wagtailmenus 3.1 release notes (IN DEVELOPMENT)
 What's new?
 ===========
 
-TBA
+* New documentation section: :ref:`recipes`.
 
 
 Minor changes & bug fixes
 =========================
 
-* Added support for Wagtail 2.10 (no code changes necessary)
+* Added support for Django 4.0
 * Updated menu classes to better support cases where 'request' and 'site' are not available in the context
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requires = [
 ]
 
 testing_extras = [
-    'beautifulsoup4<4.6.1,>=4.5.1',
+    'beautifulsoup4',
     'coverage>=4.5',
     'django-webtest>=1.9,<1.10',
 ]
@@ -68,11 +68,17 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
         'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/wagtailmenus/conf/constants.py
+++ b/wagtailmenus/conf/constants.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 MAX_LEVELS_CHOICES = (

--- a/wagtailmenus/forms.py
+++ b/wagtailmenus/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 
 from wagtailmenus.conf import settings

--- a/wagtailmenus/modeladmin.py
+++ b/wagtailmenus/modeladmin.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 from django.contrib.admin.utils import quote
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.contrib.modeladmin.options import ModelAdmin
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
 

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -2,7 +2,7 @@ from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
 from wagtail.core.models import Page, Orderable

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -8,7 +8,7 @@ from django.http import HttpRequest
 from django.template.loader import get_template, select_template
 from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from wagtail.core import hooks
 from wagtail.core.models import Page, Site

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import HttpResponse
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.core.models import Page
 
 from wagtailmenus.conf import settings

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -1,7 +1,7 @@
 from distutils.version import LooseVersion
 
 from django.conf import settings as django_settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.edit_handlers import (
     FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
     PageChooserPanel, ObjectList, TabbedInterface

--- a/wagtailmenus/tests/test_custom_models.py
+++ b/wagtailmenus/tests/test_custom_models.py
@@ -76,7 +76,7 @@ class TestCustomMenuItemsGerman(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class=""><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Etwa <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Abschnitt zu Hause</a></li>
@@ -85,7 +85,7 @@ class TestCustomMenuItemsGerman(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; Veranstaltungen <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -94,7 +94,7 @@ class TestCustomMenuItemsGerman(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -155,7 +155,7 @@ class TestCustomMenuItemsFrench(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class=""><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Sur <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Section accueil</a></li>
@@ -164,7 +164,7 @@ class TestCustomMenuItemsFrench(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Nouvelles et événements <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -173,7 +173,7 @@ class TestCustomMenuItemsFrench(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -257,7 +257,7 @@ class TestCustomMenuModels(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class=""><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Section home</a></li>
@@ -266,7 +266,7 @@ class TestCustomMenuModels(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -275,7 +275,7 @@ class TestCustomMenuModels(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -299,7 +299,7 @@ class TestCustomMenuModels(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class=""><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Etwa <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Abschnitt zu Hause</a></li>
@@ -308,7 +308,7 @@ class TestCustomMenuModels(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; Veranstaltungen <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -317,7 +317,7 @@ class TestCustomMenuModels(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>

--- a/wagtailmenus/tests/test_menu_rendering.py
+++ b/wagtailmenus/tests/test_menu_rendering.py
@@ -121,7 +121,7 @@ class TestTemplateTags(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class="active"><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Section home</a></li>
@@ -130,7 +130,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -139,7 +139,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -165,11 +165,11 @@ class TestTemplateTags(TestCase):
         <div id="main-menu-three-levels">
             <ul class="nav navbar-nav">
                 <li class="active"><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Section home</a></li>
-                        <li class=" dropdown">
+                        <li class="dropdown">
                             <a href="/about-us/meet-the-team/" class="dropdown-toggle" id="ddtoggle_7" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Meet the team <span class="caret"></span></a>
                             <ul class="dropdown-menu" aria-labelledby="ddtoggle_7">
                                 <li class=""><a href="/about-us/meet-the-team/staff-member-one/">Staff member one</a></li>
@@ -181,7 +181,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -190,7 +190,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -218,7 +218,7 @@ class TestTemplateTags(TestCase):
                 <li class="active">
                     <a href="http://www.wagtailmenus.co.uk:8000/">Home</a>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="http://www.wagtailmenus.co.uk:8000/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class="">
@@ -235,7 +235,7 @@ class TestTemplateTags(TestCase):
                         </li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="http://www.wagtailmenus.co.uk:8000/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class="">
@@ -252,7 +252,7 @@ class TestTemplateTags(TestCase):
                 <li class="">
                     <a href="http://google.co.uk">Google</a>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="http://www.wagtailmenus.co.uk:8000/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support">
@@ -385,7 +385,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -394,7 +394,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -426,7 +426,7 @@ class TestTemplateTags(TestCase):
                         <li class="active">
                             <a href="/about-us/">Section home</a>
                         </li>
-                        <li class=" dropdown">
+                        <li class="dropdown">
                             <a href="/about-us/meet-the-team/" class="dropdown-toggle" id="ddtoggle_7" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Meet the team <span class="caret"></span></a>
                             <ul class="dropdown-menu" aria-labelledby="ddtoggle_7">
                                 <li class=""><a href="/about-us/meet-the-team/staff-member-one/">Staff member one</a></li>
@@ -438,7 +438,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -447,7 +447,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -475,7 +475,7 @@ class TestTemplateTags(TestCase):
                     <li class="active">
                         <a href="http://www.wagtailmenus.co.uk:8000/">Home</a>
                     </li>
-                    <li class=" dropdown">
+                    <li class="dropdown">
                         <a href="http://www.wagtailmenus.co.uk:8000/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                         <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                             <li class="">
@@ -492,7 +492,7 @@ class TestTemplateTags(TestCase):
                             </li>
                         </ul>
                     </li>
-                    <li class=" dropdown">
+                    <li class="dropdown">
                         <a href="http://www.wagtailmenus.co.uk:8000/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                         <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                             <li class="">
@@ -509,7 +509,7 @@ class TestTemplateTags(TestCase):
                     <li class="">
                         <a href="http://google.co.uk">Google</a>
                     </li>
-                    <li class=" dropdown">
+                    <li class="dropdown">
                         <a href="http://www.wagtailmenus.co.uk:8000/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                         <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                             <li class="support">
@@ -909,7 +909,7 @@ class TestTemplateTags(TestCase):
         <div id="main-menu-two-levels">
             <ul class="nav navbar-nav">
                 <li class=""><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_6">
                         <li class=""><a href="/about-us/">Section home</a></li>
@@ -918,7 +918,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -927,7 +927,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -1007,7 +1007,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -1016,7 +1016,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -1106,7 +1106,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_14">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -1115,7 +1115,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="dropdown-menu" aria-labelledby="ddtoggle_18">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>
@@ -1215,7 +1215,7 @@ class TestTemplateTags(TestCase):
         <div id="main-menu-sub-menu-templates">
             <ul class="nav navbar-nav">
                 <li class="active"><a href="/">Home</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/about-us/" class="dropdown-toggle" id="ddtoggle_6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About <span class="caret"></span></a>
                     <ul class="sub-menu-level-2" data-level="2">
                         <li class=""><a href="/about-us/">Section home</a></li>
@@ -1231,7 +1231,7 @@ class TestTemplateTags(TestCase):
                         <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
                     </ul>
                 </li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/news-and-events/" class="dropdown-toggle" id="ddtoggle_14" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">News &amp; events <span class="caret"></span></a>
                     <ul class="sub-menu-level-2" data-level="2">
                         <li class=""><a href="/news-and-events/latest-news/">Latest news</a></li>
@@ -1240,7 +1240,7 @@ class TestTemplateTags(TestCase):
                     </ul>
                 </li>
                 <li class=""><a href="http://google.co.uk">Google</a></li>
-                <li class=" dropdown">
+                <li class="dropdown">
                     <a href="/contact-us/" class="dropdown-toggle" id="ddtoggle_18" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Contact us <span class="caret"></span></a>
                     <ul class="sub-menu-level-2" data-level="2">
                         <li class="support"><a href="/contact-us/#support">Get support</a></li>


### PR DESCRIPTION
This addresses #382 and #403

- Add support for Django 4.0
- Fixed a typo on the fixtures
- Add "Recipes" section with an example on how to translate a custom main menu i18n

Some caveats:
- I was unable to upgrade tox since Wagtail 2.15 has a Django <3.3 dependencies.

When that was solved, ideally we would want to drop support from Wagtail <2.11 and Django <2.2 since they are no longer supported.