### PR TITLE
Fix autopopulate_main_menus instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -104,7 +104,7 @@ Installing wagtailmenus
 
     .. code-block:: console
 
-        python manage.py autopopulate_main_menus --add-home-links=True
+        python manage.py autopopulate_main_menus --add-home-links
 
     This would create a main menu with the following items:
 


### PR DESCRIPTION
In version 3.0.2 at least, the `=True` part isn't recognized and generates an error:

```
$ python manage.py autopopulate_main_menus --add-home-links=True
usage: manage.py autopopulate_main_menus [-h] [--add-home-links] [--version] [-v {0,1,2,3}] [--settings SETTINGS] [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
manage.py autopopulate_main_menus: error: argument --add-home-links: ignored explicit argument 'True'
```