### PR TITLE
Fix wagtailmenus compatibility issue with Wagtail 3.0 with updates to module paths and supported test version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0']
-        wagtail-version: ['2.15', '2.16']
+        wagtail-version: ['2.15', '2.16', '3.0']
         exclude:
           - python-version: '3.7'
             django-version: '4.0'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,23 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0']
-        wagtail-version: ['3.0']
+        wagtail-version: ['2.15', '2.16']
+        exclude:
+          - python-version: '3.7'
+            django-version: '4.0'
+            wagtail-version: '2.15'
+          - python-version: '3.7'
+            django-version: '4.0'
+            wagtail-version: '2.16'
+          - python-version: '3.8'
+            django-version: '4.0'
+            wagtail-version: '2.15'
+          - python-version: '3.9'
+            django-version: '4.0'
+            wagtail-version: '2.15'
+          - python-version: '3.10'
+            django-version: '4.0'
+            wagtail-version: '2.15'
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,23 +14,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['3.2', '4.0']
-        wagtail-version: ['2.15', '2.16']
-        exclude:
-          - python-version: '3.7'
-            django-version: '4.0'
-            wagtail-version: '2.15'
-          - python-version: '3.7'
-            django-version: '4.0'
-            wagtail-version: '2.16'
-          - python-version: '3.8'
-            django-version: '4.0'
-            wagtail-version: '2.15'
-          - python-version: '3.9'
-            django-version: '4.0'
-            wagtail-version: '2.15'
-          - python-version: '3.10'
-            django-version: '4.0'
-            wagtail-version: '2.15'
+        wagtail-version: ['3.0']
     steps:
     - uses: actions/checkout@v2
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,6 +27,7 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to
 * Sekani Tembo (Method Softworks)
 * Fernando Cordeiro (MrCordeiro)
   twitter.com/brauhaus
+* Abdulmajeed Isa (amajai)
 
 ## Translators
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Wagtail :: 2',
+        'Framework :: Wagtail :: 3',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ testing_extras = [
 ]
 
 development_extras = [
-    'wagtail>=2.15',
+    'wagtail>=3.0',
     'django-debug-toolbar',
     'django-extensions',
     'ipdb',
@@ -68,7 +68,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
-        'Framework :: Wagtail :: 2',
+        'Framework :: Wagtail :: 3',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ testing_extras = [
 ]
 
 development_extras = [
-    'wagtail>=3.0',
+    'wagtail>=2.15',
     'django-debug-toolbar',
     'django-extensions',
     'ipdb',
@@ -68,7 +68,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
-        'Framework :: Wagtail :: 3',
+        'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -13,14 +13,15 @@ DJANGO =
 WAGTAIL =
     2.15: wt215
     2.16: wt216
+    3.0: wt30
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{37,38,39,310}-dj32-wt{215,216}
-    py{38,39,310}-dj40-wt216
+    py{37,38,39,310}-dj32-wt{215,216,30}
+    py{38,39,310}-dj40-wt{216,30}
 
 [testenv]
 description = Unit tests
@@ -38,3 +39,4 @@ deps =
     dj40: Django>=4.0,<4.1
     wt215: wagtail>=2.15,<2.16
     wt216: wagtail>=2.16,<2.17
+    wt30: wagtail>=3.0,<3.1

--- a/tox.ini
+++ b/tox.ini
@@ -11,16 +11,15 @@ DJANGO =
     4.0: dj40
 
 WAGTAIL =
-    2.15: wt215
-    2.16: wt216
+    3.0: wt30
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{37,38,39,310}-dj32-wt{215,216}
-    py{38,39,310}-dj40-wt216
+    py{37,38,39,310}-dj32-wt30
+    py{38,39,310}-dj40-wt30
 
 [testenv]
 description = Unit tests
@@ -36,5 +35,4 @@ basepython =
 deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
-    wt215: wagtail>=2.15,<2.16
-    wt216: wagtail>=2.16,<2.17
+    wt30: wagtail>=3.0,<3.1

--- a/tox.ini
+++ b/tox.ini
@@ -11,15 +11,16 @@ DJANGO =
     4.0: dj40
 
 WAGTAIL =
-    3.0: wt30
+    2.15: wt215
+    2.16: wt216
 
 [tox]
 skipsdist = True
 usedevelop = True
 
 envlist =
-    py{37,38,39,310}-dj32-wt30
-    py{38,39,310}-dj40-wt30
+    py{37,38,39,310}-dj32-wt{215,216}
+    py{38,39,310}-dj40-wt216
 
 [testenv]
 description = Unit tests
@@ -35,4 +36,5 @@ basepython =
 deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
-    wt30: wagtail>=3.0,<3.1
+    wt215: wagtail>=2.15,<2.16
+    wt216: wagtail>=2.16,<2.17

--- a/wagtailmenus/management/commands/autopopulate_main_menus.py
+++ b/wagtailmenus/management/commands/autopopulate_main_menus.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from wagtailmenus.conf import settings
 

--- a/wagtailmenus/management/commands/autopopulate_main_menus.py
+++ b/wagtailmenus/management/commands/autopopulate_main_menus.py
@@ -1,9 +1,11 @@
 import logging
 
 from django.core.management.base import BaseCommand
-from wagtail.models import Site
-
 from wagtailmenus.conf import settings
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 
 logger = logging.getLogger(__name__)
 

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -4,8 +4,8 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
-from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
-from wagtail.core.models import Page, Orderable
+from wagtail.admin.panels import FieldPanel, PageChooserPanel
+from wagtail.models import Page, Orderable
 
 from wagtailmenus.conf import settings
 from wagtailmenus.managers import MenuItemManager

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -4,11 +4,14 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey
-from wagtail.admin.panels import FieldPanel, PageChooserPanel
-from wagtail.models import Page, Orderable
-
 from wagtailmenus.conf import settings
 from wagtailmenus.managers import MenuItemManager
+try:
+    from wagtail.admin.panels import FieldPanel, PageChooserPanel
+    from wagtail.models import Page, Orderable
+except ImportError:
+    from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
+    from wagtail.core.models import Page, Orderable
 
 
 #########################################################

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -10,8 +10,8 @@ from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
-from wagtail.core import hooks
-from wagtail.core.models import Page, Site
+from wagtail import hooks
+from wagtail.models import Page, Site
 
 from wagtailmenus import forms, panels
 from wagtailmenus.conf import constants, settings

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -10,8 +10,13 @@ from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
-from wagtail import hooks
-from wagtail.models import Page, Site
+try:
+    from wagtail import hooks
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core import hooks
+    from wagtail.core.models import Page, Site
+
 
 from wagtailmenus import forms, panels
 from wagtailmenus.conf import constants, settings

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -7,11 +7,13 @@ from django.db import models
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
-from wagtail.models import Page
-
 from wagtailmenus.conf import settings
 from wagtailmenus.forms import LinkPageAdminForm
 from wagtailmenus.panels import menupage_settings_panels, linkpage_edit_handler
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 
 class MenuPageMixin(models.Model):

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
-from wagtail.core.models import Page
+from wagtail.models import Page
 
 from wagtailmenus.conf import settings
 from wagtailmenus.forms import LinkPageAdminForm

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -2,7 +2,7 @@ from distutils.version import LooseVersion
 
 from django.conf import settings as django_settings
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.edit_handlers import (
+from wagtail.admin.panels import (
     FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
     PageChooserPanel, ObjectList, TabbedInterface
 )

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -2,12 +2,17 @@ from distutils.version import LooseVersion
 
 from django.conf import settings as django_settings
 from django.utils.translation import gettext_lazy as _
-from wagtail.admin.panels import (
-    FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
-    PageChooserPanel, ObjectList, TabbedInterface
-)
-
 from wagtailmenus.conf import settings
+try:
+    from wagtail.admin.panels import (
+        FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
+        PageChooserPanel, ObjectList, TabbedInterface
+    )
+except ImportError:
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
+        PageChooserPanel, ObjectList, TabbedInterface
+    )
 
 
 # ########################################################

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -24,7 +24,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'wagtail.admin',
-    'wagtail.core',
+    'wagtail',
     'wagtail.documents',
     'wagtail.embeds',
     'wagtail.images',

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -24,7 +24,7 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'wagtail.admin',
-    'wagtail',
+    'wagtail.core',
     'wagtail.documents',
     'wagtail.embeds',
     'wagtail.images',

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -1,9 +1,11 @@
 from django.template import Library
-from wagtail.models import Page
-
 from wagtailmenus.conf import constants, settings
 from wagtailmenus.errors import SubMenuUsageError
 from wagtailmenus.utils.misc import validate_supplied_values
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 register = Library()
 

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from wagtail.core.models import Page
+from wagtail.models import Page
 
 from wagtailmenus.conf import constants, settings
 from wagtailmenus.errors import SubMenuUsageError

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -1,13 +1,16 @@
 from django.db import models
 from modelcluster.fields import ParentalKey
-from wagtail.admin.panels import (
-    FieldPanel, MultiFieldPanel, PageChooserPanel)
-
 from wagtailmenus.models import (
     SectionMenu, ChildrenMenu, AbstractMainMenu,
     AbstractMainMenuItem, AbstractFlatMenu, AbstractFlatMenuItem)
 
 from .utils import TranslatedField
+try:
+    from wagtail.admin.panels import (
+        FieldPanel, MultiFieldPanel, PageChooserPanel)
+except ImportError:
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PageChooserPanel)
 
 
 class CustomChildrenMenu(ChildrenMenu):

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -1,6 +1,6 @@
 from django.db import models
 from modelcluster.fields import ParentalKey
-from wagtail.admin.edit_handlers import (
+from wagtail.admin.panels import (
     FieldPanel, MultiFieldPanel, PageChooserPanel)
 
 from wagtailmenus.models import (

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -3,11 +3,11 @@ from datetime import date
 from django.db import models
 from django.http import Http404
 from django.template.response import TemplateResponse
-from wagtail.admin.edit_handlers import (
+from wagtail.admin.panels import (
     FieldPanel, MultiFieldPanel, PublishingPanel
 )
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
-from wagtail.core.models import Page
+from wagtail.models import Page
 
 from wagtailmenus.models import MenuPage, AbstractLinkPage
 from .utils import TranslatedField

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -3,14 +3,19 @@ from datetime import date
 from django.db import models
 from django.http import Http404
 from django.template.response import TemplateResponse
-from wagtail.admin.panels import (
-    FieldPanel, MultiFieldPanel, PublishingPanel
-)
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
-from wagtail.models import Page
-
 from wagtailmenus.models import MenuPage, AbstractLinkPage
 from .utils import TranslatedField
+try:
+    from wagtail.admin.panels import (
+        FieldPanel, MultiFieldPanel, PublishingPanel
+    )
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PublishingPanel
+    )
+    from wagtail.core.models import Page
 
 
 class MultilingualMenuPage(MenuPage):

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -6,8 +6,8 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase, override_settings
 
 from django_webtest import WebTest
-from wagtail.admin.edit_handlers import ObjectList
-from wagtail.core.models import Page, Site
+from wagtail.admin.panels import ObjectList
+from wagtail.models import Page, Site
 
 from wagtailmenus import get_flat_menu_model, get_main_menu_model
 

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -6,12 +6,15 @@ from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase, override_settings
 
 from django_webtest import WebTest
-from wagtail.admin.panels import ObjectList
-from wagtail.models import Page, Site
-
 from wagtailmenus import get_flat_menu_model, get_main_menu_model
 
 from wagtailmenus.tests.models import LinkPage
+try:
+    from wagtail.admin.panels import ObjectList
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.admin.edit_handlers import ObjectList
+    from wagtail.core.models import Page, Site
 
 FlatMenu = get_flat_menu_model()
 

--- a/wagtailmenus/tests/test_base_menu_classes.py
+++ b/wagtailmenus/tests/test_base_menu_classes.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from wagtail.core.models import Page, Site
+from wagtail.models import Page, Site
 
 from wagtailmenus.errors import RequestUnavailableError
 from wagtailmenus.models import Menu, MenuWithMenuItems

--- a/wagtailmenus/tests/test_base_menu_classes.py
+++ b/wagtailmenus/tests/test_base_menu_classes.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
-
-from wagtail.models import Page, Site
-
 from wagtailmenus.errors import RequestUnavailableError
 from wagtailmenus.models import Menu, MenuWithMenuItems
+try:
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core.models import Page, Site
 
 
 class TestMenuGetSite(TestCase):

--- a/wagtailmenus/tests/test_commands.py
+++ b/wagtailmenus/tests/test_commands.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.core.management import call_command
-from wagtail.core.models import Site
+from wagtail.models import Site
 from wagtailmenus.conf import settings
 
 

--- a/wagtailmenus/tests/test_commands.py
+++ b/wagtailmenus/tests/test_commands.py
@@ -1,7 +1,10 @@
 from django.test import TestCase
 from django.core.management import call_command
-from wagtail.models import Site
 from wagtailmenus.conf import settings
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 
 
 class TestAutoPopulateMainMenus(TestCase):

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from bs4 import BeautifulSoup
 from django.test import TestCase
-from wagtail.core import hooks
+from wagtail import hooks
 
 
 class TestHooks(TestCase):

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from bs4 import BeautifulSoup
 from django.test import TestCase
-from wagtail import hooks
-
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 class TestHooks(TestCase):
     fixtures = ['test.json']

--- a/wagtailmenus/tests/test_menu_items.py
+++ b/wagtailmenus/tests/test_menu_items.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import RequestFactory
-from wagtail.core.models import Page
+from wagtail.models import Page
 
 from wagtailmenus.conf import settings
 from wagtailmenus.models import (

--- a/wagtailmenus/tests/test_menu_items.py
+++ b/wagtailmenus/tests/test_menu_items.py
@@ -1,12 +1,14 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.client import RequestFactory
-from wagtail.models import Page
-
 from wagtailmenus.conf import settings
 from wagtailmenus.models import (
     AbstractMenuItem, MainMenu, MainMenuItem, FlatMenu, FlatMenuItem
 )
+try:
+    from wagtail.models import Page
+except ImportError:
+    from wagtail.core.models import Page
 
 
 class MenuItemModelTestMixin:

--- a/wagtailmenus/tests/test_menu_rendering.py
+++ b/wagtailmenus/tests/test_menu_rendering.py
@@ -1,10 +1,12 @@
 from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
-from wagtail.core.models import Site
-
 from wagtailmenus.errors import SubMenuUsageError
 from wagtailmenus.models import MainMenu, FlatMenu
 from wagtailmenus.templatetags.menu_tags import validate_supplied_values
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 
 
 class TestTemplateTags(TestCase):

--- a/wagtailmenus/tests/test_page_models.py
+++ b/wagtailmenus/tests/test_page_models.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
-from wagtail.models import Site
-
 from wagtailmenus.tests.models import LinkPage
+try:
+    from wagtail.models import Site
+except ImportError:
+    from wagtail.core.models import Site
 
 
 class TestLinkPage(TestCase):

--- a/wagtailmenus/tests/test_page_models.py
+++ b/wagtailmenus/tests/test_page_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from wagtailmenus.tests.models import LinkPage
 

--- a/wagtailmenus/tests/urls.py
+++ b/wagtailmenus/tests/urls.py
@@ -2,8 +2,7 @@ from django.conf.urls import include
 from django.urls import re_path
 from django.views.generic import TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail import urls as wagtail_urls
-
+from wagtail.core import urls as wagtail_urls
 
 urlpatterns = [
     re_path(r'^admin/', include(wagtailadmin_urls)),

--- a/wagtailmenus/tests/urls.py
+++ b/wagtailmenus/tests/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include
 from django.urls import re_path
 from django.views.generic import TemplateView
 from wagtail.admin import urls as wagtailadmin_urls
-from wagtail.core import urls as wagtail_urls
+from wagtail import urls as wagtail_urls
 
 
 urlpatterns = [

--- a/wagtailmenus/tests/utils.py
+++ b/wagtailmenus/tests/utils.py
@@ -12,12 +12,12 @@ SINGLE_ITEM_SUB_MENU_TEMPLATE_LIST = ('menus/sub_menu_level_2.html',)
 
 
 def get_page_model():
-    from wagtail.core.models import Page
+    from wagtail.models import Page
     return Page
 
 
 def get_site_model():
-    from wagtail.core.models import Site
+    from wagtail.models import Site
     return Site
 
 

--- a/wagtailmenus/tests/utils.py
+++ b/wagtailmenus/tests/utils.py
@@ -12,12 +12,18 @@ SINGLE_ITEM_SUB_MENU_TEMPLATE_LIST = ('menus/sub_menu_level_2.html',)
 
 
 def get_page_model():
-    from wagtail.models import Page
+    try:
+        from wagtail.models import Page
+    except ImportError:
+        from wagtail.core.models import Page
     return Page
 
 
 def get_site_model():
-    from wagtail.models import Site
+    try:
+        from wagtail.models import Site
+    except ImportError:
+        from wagtail.core.models import Site
     return Site
 
 

--- a/wagtailmenus/utils/inspection.py
+++ b/wagtailmenus/utils/inspection.py
@@ -1,7 +1,7 @@
 import inspect
 
 """
-This method below was copied from wagtail.utils (v1.11) and allows
+This method below was copied from wagtail.wagtailcore.utils (v1.11) and allows
 us to handle deprecation of method arguments in a way that doesn't swallow
 `TypeError` exceptions raised further down the chain. Thank you @gasman!
 """

--- a/wagtailmenus/utils/inspection.py
+++ b/wagtailmenus/utils/inspection.py
@@ -1,7 +1,7 @@
 import inspect
 
 """
-This method below was copied from wagtail.wagtailcore.utils (v1.11) and allows
+This method below was copied from wagtail.utils (v1.11) and allows
 us to handle deprecation of method arguments in a way that doesn't swallow
 `TypeError` exceptions raised further down the chain. Thank you @gasman!
 """

--- a/wagtailmenus/utils/misc.py
+++ b/wagtailmenus/utils/misc.py
@@ -1,5 +1,5 @@
 from django.http import Http404, HttpRequest
-from wagtail.core.models import Page, Site
+from wagtail.models import Page, Site
 
 from wagtailmenus.models.menuitems import MenuItem
 

--- a/wagtailmenus/utils/misc.py
+++ b/wagtailmenus/utils/misc.py
@@ -1,7 +1,10 @@
 from django.http import Http404, HttpRequest
-from wagtail.models import Page, Site
 
 from wagtailmenus.models.menuitems import MenuItem
+try:
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core.models import Page, Site
 
 
 def get_fake_site():

--- a/wagtailmenus/utils/tests/test_misc.py
+++ b/wagtailmenus/utils/tests/test_misc.py
@@ -1,8 +1,5 @@
 from django.test import RequestFactory, TestCase, modify_settings
 from distutils.version import LooseVersion
-from wagtail import __version__ as wagtail_version
-from wagtail.models import Page, Site
-
 from wagtailmenus.conf import defaults
 from wagtailmenus.utils.misc import (
     derive_page, derive_section_root, get_fake_request, get_site_from_request
@@ -10,6 +7,12 @@ from wagtailmenus.utils.misc import (
 from wagtailmenus.tests.models import (
     ArticleListPage, ArticlePage, LowLevelPage, TopLevelPage
 )
+try:
+    from wagtail import __version__ as wagtail_version
+    from wagtail.models import Page, Site
+except ImportError:
+    from wagtail.core import __version__ as wagtail_version
+    from wagtail.core.models import Page, Site
 
 
 class TestGetFakeRequest(TestCase):
@@ -291,7 +294,7 @@ class TestGetSiteFromRequest(TestCase):
 
     @modify_settings(MIDDLEWARE={
         'append': 'django.contrib.sites.middleware.CurrentSiteMiddleware',
-        'remove': 'wagtail.middleware.SiteMiddleware',
+        'remove': 'wagtail.core.middleware.SiteMiddleware',
     })
     def test_with_django_site_in_request_wagtail_29_and_above(self):
         """
@@ -300,7 +303,7 @@ class TestGetSiteFromRequest(TestCase):
         if self.is_wagtail_29_or_above:
             self._run_test()
 
-    @modify_settings(MIDDLEWARE={'remove': 'wagtail.middleware.SiteMiddleware'})
+    @modify_settings(MIDDLEWARE={'remove': 'wagtail.core.middleware.SiteMiddleware'})
     def test_with_no_site_in_request_wagtail_29_and_above(self):
         """
         Test when no Site object exists at request.site for Wagtail 2.9 and above.

--- a/wagtailmenus/utils/tests/test_misc.py
+++ b/wagtailmenus/utils/tests/test_misc.py
@@ -1,7 +1,7 @@
 from django.test import RequestFactory, TestCase, modify_settings
 from distutils.version import LooseVersion
-from wagtail.core import __version__ as wagtail_version
-from wagtail.core.models import Page, Site
+from wagtail import __version__ as wagtail_version
+from wagtail.models import Page, Site
 
 from wagtailmenus.conf import defaults
 from wagtailmenus.utils.misc import (
@@ -291,7 +291,7 @@ class TestGetSiteFromRequest(TestCase):
 
     @modify_settings(MIDDLEWARE={
         'append': 'django.contrib.sites.middleware.CurrentSiteMiddleware',
-        'remove': 'wagtail.core.middleware.SiteMiddleware',
+        'remove': 'wagtail.middleware.SiteMiddleware',
     })
     def test_with_django_site_in_request_wagtail_29_and_above(self):
         """
@@ -300,7 +300,7 @@ class TestGetSiteFromRequest(TestCase):
         if self.is_wagtail_29_or_above:
             self._run_test()
 
-    @modify_settings(MIDDLEWARE={'remove': 'wagtail.core.middleware.SiteMiddleware'})
+    @modify_settings(MIDDLEWARE={'remove': 'wagtail.middleware.SiteMiddleware'})
     def test_with_no_site_in_request_wagtail_29_and_above(self):
         """
         Test when no Site object exists at request.site for Wagtail 2.9 and above.

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -54,6 +54,9 @@ class MenuTabbedInterfaceMixin:
                 ObjectList(self.model.settings_panels, heading=_("Settings"),
                            classname="settings"),
             ])
+        if hasattr(edit_handler, 'bind_to'):
+            # For Wagtail>=2.5
+            return edit_handler.bind_to(model=self.model)
         return edit_handler.bind_to_model(self.model)
 
     def form_invalid(self, form):

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -54,9 +54,6 @@ class MenuTabbedInterfaceMixin:
                 ObjectList(self.model.settings_panels, heading=_("Settings"),
                            classname="settings"),
             ])
-        if hasattr(edit_handler, 'bind_to'):
-            # For Wagtail>=2.5
-            return edit_handler.bind_to(model=self.model)
         return edit_handler.bind_to_model(self.model)
 
     def form_invalid(self, form):

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -7,13 +7,19 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
-from wagtail.admin.panels import ObjectList, TabbedInterface
 from wagtail.contrib.modeladmin.views import (
     WMABaseView, CreateView, EditView, ModelFormView
 )
-from wagtail.models import Site
-
 from wagtailmenus.conf import settings
+from distutils.version import LooseVersion
+try:
+    from wagtail import __version__ as wagtail_version
+    from wagtail.models import Site
+    from wagtail.admin.panels import ObjectList, TabbedInterface
+except ImportError:
+    from wagtail.core import __version__ as wagtail_version
+    from wagtail.core.models import Site
+    from wagtail.admin.edit_handlers import ObjectList, TabbedInterface
 
 
 class SiteSwitchForm(forms.Form):
@@ -54,8 +60,8 @@ class MenuTabbedInterfaceMixin:
                 ObjectList(self.model.settings_panels, heading=_("Settings"),
                            classname="settings"),
             ])
-        if hasattr(edit_handler, 'bind_to'):
-            # For Wagtail>=2.5
+        if LooseVersion(wagtail_version) < LooseVersion('3.0'):
+            # For Wagtail>=2.5,<3.0
             return edit_handler.bind_to(model=self.model)
         return edit_handler.bind_to_model(self.model)
 

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -7,11 +7,11 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
-from wagtail.admin.edit_handlers import ObjectList, TabbedInterface
+from wagtail.admin.panels import ObjectList, TabbedInterface
 from wagtail.contrib.modeladmin.views import (
     WMABaseView, CreateView, EditView, ModelFormView
 )
-from wagtail.core.models import Site
+from wagtail.models import Site
 
 from wagtailmenus.conf import settings
 

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -1,4 +1,3 @@
-from wagtail import hooks
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from wagtailmenus.conf import settings
@@ -6,6 +5,10 @@ from wagtailmenus.utils.misc import derive_section_root
 from wagtailmenus.modeladmin import ( # noqa
     MainMenuAdmin, FlatMenuAdmin, FlatMenuButtonHelper
 )
+try:
+    from wagtail import hooks
+except ImportError:
+    from wagtail.core import hooks
 
 if settings.MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN:
     modeladmin_register(settings.objects.MAIN_MENUS_MODELADMIN_CLASS)

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from wagtail.core import hooks
+from wagtail import hooks
 from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from wagtailmenus.conf import settings


### PR DESCRIPTION
Fix for #421 

This line of code below is causing an error in 3.0.
https://github.com/jazzband/wagtailmenus/blob/8be2790c01688dd3c9ef7298bdebe94575c0a76a/wagtailmenus/views.py#L60 

Added a conditional statement to run the line of code if the version on wagtail is below 3.0.

Since Wagtail 3.0 modules have been reorganized, updating the module paths was required.  Added an ImportError exception to all the wagtail Imports for versions before and after 3.0 to be backward compatible.    

Updated the test version of wagtail.

