### PR TITLE
Add compatibility for Django 4.1

### DIFF
--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,6 +1,8 @@
 from collections import defaultdict, namedtuple, OrderedDict
 from types import GeneratorType
 
+from distutils.version import LooseVersion
+from django import __version__ as django_version
 from django.db import models
 from django.db.models import BooleanField, Case, Q, When
 from django.core.exceptions import ImproperlyConfigured, MultipleObjectsReturned
@@ -26,8 +28,10 @@ from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
-
-mark_safe_lazy = lazy(mark_safe, str)
+if LooseVersion(django_version) >= LooseVersion('4.1'):
+    mark_safe_lazy = mark_safe
+else:
+    mark_safe_lazy = lazy(mark_safe, str)
 
 ContextualVals = namedtuple('ContextualVals', (
     'parent_context',

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -28,6 +28,7 @@ from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
+
 if LooseVersion(django_version) >= LooseVersion('4.1'):
     mark_safe_lazy = mark_safe
 else:


### PR DESCRIPTION
`django.utils.safestring.mark_safe` [now preserves lazy objects in version 4.1+](https://docs.djangoproject.com/en/4.1/releases/4.1/#utilities) so this commit sets the `mark_safe_lazy` function conditionally for compatibility