### PR TITLE
Wagtail 4.0 update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,10 @@ jobs:
             django-version: '4.0'
             wagtail-version: '2.15'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -46,7 +46,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
     
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:
@@ -66,6 +66,6 @@ jobs:
         WAGTAIL: ${{ matrix.wagtail-version }}
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         name: Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+------------------
+
+* Removed usage of the deprecated distutils.
+* Added new variables in settings to suppress warnings.
+* Fixed formatting, removed unused imports.
+* Updated workflow action versions.
+
 3.1.3 (15.10.2022)
 ------------------
 

--- a/docs/source/advanced_topics/custom_menu_classes.rst
+++ b/docs/source/advanced_topics/custom_menu_classes.rst
@@ -34,8 +34,8 @@ If you're happy with the default ``MainMenu`` model, but wish customise the menu
         from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
         from wagtail.images import get_image_model_string
-        from wagtail.images.edit_handlers import ImageChooserPanel
-        from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
+        from wagtail.images.panels import ImageChooserPanel
+        from wagtail.admin.panels import FieldPanel, PageChooserPanel
         from wagtailmenus.models import AbstractMainMenuItem
 
 
@@ -113,7 +113,7 @@ If you also need to override the ``MainMenu`` model, that's possible too. But, b
         from django.utils.translation import gettext_lazy as _
         from django.utils import timezone
         from modelcluster.fields import ParentalKey
-        from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
+        from wagtail.admin.panels import FieldPanel, MultiFieldPanel, PageChooserPanel
         from wagtailmenus.conf import settings
         from wagtailmenus.models import AbstractMainMenu, AbstractMainMenuItem
 
@@ -209,8 +209,8 @@ If you're happy with the default ``FlatMenu`` model, but wish customise the menu
         from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
         from wagtail.images import get_image_model_string
-        from wagtail.images.edit_handlers import ImageChooserPanel
-        from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
+        from wagtail.images.panels import ImageChooserPanel
+        from wagtail.admin.panels import FieldPanel, PageChooserPanel
         from wagtailmenus.models import AbstractFlatMenuItem
 
 
@@ -289,7 +289,7 @@ If you also need to override the ``FlatMenu`` model, that's possible too. But, b
         from django.utils import translation
         from django.utils.translation import gettext_lazy as _
         from modelcluster.fields import ParentalKey
-        from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
+        from wagtail.admin.panels import FieldPanel, MultiFieldPanel, PageChooserPanel
         from wagtailmenus.conf import settings
         from wagtailmenus.panels import FlatMenuItemsInlinePanel
         from wagtailmenus.models import AbstractFlatMenu, AbstractFlatMenuItem
@@ -437,7 +437,7 @@ The class ``wagtailmenus.models.menus.SectionMenu`` is used by default, but you 
     # mysite/appname/models.py
 
     from django.utils.translation import gettext_lazy as _
-    from wagtail.core.models import Page
+    from wagtail.models import Page
     from wagtailmenus.models import SectionMenu
 
 
@@ -472,7 +472,7 @@ The class ``wagtailmenus.models.menus.ChildrenMenu`` is used by default, but you
     # appname/menus.py
 
     from django.utils.translation import gettext_lazy as _
-    from wagtail.core.models import Page
+    from wagtail.models import Page
     from wagtailmenus.models import ChildrenMenu
 
 

--- a/docs/source/advanced_topics/hooks.rst
+++ b/docs/source/advanced_topics/hooks.rst
@@ -11,7 +11,7 @@ Registering functions with a Wagtail hook is done through the ``@hooks.register`
 
 .. code-block:: python
 
-  from wagtail.core import hooks
+  from wagtail import hooks
 
   @hooks.register('name_of_hook')
   def my_hook_function(arg1, arg2...)
@@ -63,7 +63,7 @@ However, if you'd like to filter this result down further, you can do so using s
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_base_page_queryset')
     def make_some_changes(
@@ -86,7 +86,7 @@ Or, if you only wanted to change the queryset for a menu of a specific type, you
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_base_page_queryset')
     def make_some_changes(
@@ -124,7 +124,7 @@ However, if you'd only like to include a subset of the CMS-defined menu item, or
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_base_menuitem_queryset')
     def make_some_changes(
@@ -149,7 +149,7 @@ These changes would be applied to all menu types that use menu items to define t
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_base_menuitem_queryset')
     def make_some_changes(
@@ -193,7 +193,7 @@ This hook allows you to modify the list **before** it is 'primed' (a process tha
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_raw_menu_items')
     def make_some_changes(
@@ -233,7 +233,7 @@ This hook allows you to modify the list of items **after** they have been 'prime
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register('menus_modify_primed_menu_items')
     def make_some_changes(

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -203,7 +203,7 @@ Solves the problem of important page links becoming just 'toggles' in multi-leve
 =======================================================================================
 
 Extend the ``wagtailmenus.models.MenuPage`` model instead of the usual
-``wagtail.core.models.Page`` model to create your custom page types, and gain a
+``wagtail.models.Page`` model to create your custom page types, and gain a
 couple of extra fields that will allow you to configure certain pages to appear again
 alongside their children in multi-level menus. Use the menu tags provided, and that
 behaviour will remain consistent in all menus throughout your site. To find out more,

--- a/docs/source/settings_reference.rst
+++ b/docs/source/settings_reference.rst
@@ -196,7 +196,7 @@ If you have a multi-site project, and want to be able to use different templates
 
     WAGTAILMENUS_SITE_SPECIFIC_TEMPLATE_DIRS = True
 
-With this set, menu tags will attempt to identify the relevant ``wagtail.core.models.Site`` instance for the current ``request``. Wagtailmenus will then look for template names with the ``domain`` value of that ``Site`` object in their path.
+With this set, menu tags will attempt to identify the relevant ``wagtail.models.Site`` instance for the current ``request``. Wagtailmenus will then look for template names with the ``domain`` value of that ``Site`` object in their path.
 
 For more information about where wagtailmenus looks for templates, see: :ref:`custom_templates_auto`
 

--- a/wagtailmenus/context_processors.py
+++ b/wagtailmenus/context_processors.py
@@ -1,4 +1,3 @@
-from django.http import Http404
 from django.utils.functional import SimpleLazyObject
 from wagtailmenus.conf import settings
 from wagtailmenus.utils.misc import (

--- a/wagtailmenus/development/urls.py.example
+++ b/wagtailmenus/development/urls.py.example
@@ -1,13 +1,14 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
+from django.urls import re_path
 from wagtailmenus.tests import urls as test_urls
 
 urlpatterns = []
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        re_path(r'^__debug__/', include(debug_toolbar.urls)),
     ]
 urlpatterns += [
-    url(r'', include(test_urls)),
+    re_path(r'', include(test_urls)),
 ]

--- a/wagtailmenus/migrations/0010_auto_20160201_1558.py
+++ b/wagtailmenus/migrations/0010_auto_20160201_1558.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,12 +1,10 @@
 from collections import defaultdict, namedtuple, OrderedDict
 from types import GeneratorType
 
-from distutils.version import LooseVersion
-from django import __version__ as django_version
+from django import VERSION as DJANGO_VERSION
 from django.db import models
 from django.db.models import BooleanField, Case, Q, When
 from django.core.exceptions import ImproperlyConfigured, MultipleObjectsReturned
-from django.http import HttpRequest
 from django.template.loader import get_template, select_template
 from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
@@ -28,7 +26,7 @@ from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
-if LooseVersion(django_version) >= LooseVersion('4.1'):
+if DJANGO_VERSION >= (4, 1):
     mark_safe_lazy = mark_safe
 else:
     mark_safe_lazy = lazy(mark_safe, str)

--- a/wagtailmenus/models/mixins.py
+++ b/wagtailmenus/models/mixins.py
@@ -1,7 +1,6 @@
 from django.template.loader import get_template, select_template
 
 from wagtailmenus.conf import settings
-from wagtailmenus.utils.inspection import accepts_kwarg
 
 
 def get_item_by_index_or_last_item(items, index):

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -1,7 +1,5 @@
 from copy import copy
-from io import StringIO
 
-from django.conf import settings as django_settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.http import HttpResponse

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -1,6 +1,3 @@
-from distutils.version import LooseVersion
-
-from django.conf import settings as django_settings
 from django.utils.translation import gettext_lazy as _
 from wagtailmenus.conf import settings
 try:

--- a/wagtailmenus/settings/development.py.example
+++ b/wagtailmenus/settings/development.py.example
@@ -30,3 +30,7 @@ ROOT_URLCONF = 'wagtailmenus.development.urls'
 WAGTAIL_SITE_NAME = 'Wagtailmenus development'
 DEBUG_TOOLBAR_PATCH_SETTINGS = False
 INTERNAL_IPS = ['127.0.0.1']
+
+# Suppress warnings
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+WAGTAILADMIN_BASE_URL = "http://example.com"

--- a/wagtailmenus/settings/testing.py
+++ b/wagtailmenus/settings/testing.py
@@ -18,3 +18,7 @@ ROOT_URLCONF = 'wagtailmenus.tests.urls'
 WAGTAIL_SITE_NAME = 'Wagtailmenus Test'
 LOGIN_URL = 'wagtailadmin_login'
 LOGIN_REDIRECT_URL = 'wagtailadmin_home'
+
+# Suppress warnings while testing
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+WAGTAILADMIN_BASE_URL = "http://example.com"

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -1,5 +1,5 @@
 from django.template import Library
-from wagtailmenus.conf import constants, settings
+from wagtailmenus.conf import settings
 from wagtailmenus.errors import SubMenuUsageError
 from wagtailmenus.utils.misc import validate_supplied_values
 try:

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -3,8 +3,6 @@ from datetime import date
 from django.db import models
 from django.http import Http404
 from django.template.response import TemplateResponse
-from django import __version__ as django_version
-from distutils.version import LooseVersion
 from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 from wagtailmenus.models import AbstractLinkPage, MenuPage
 
@@ -198,6 +196,7 @@ class NoAbsoluteUrlsPage(MenuPage):
 
 class LinkPage(AbstractLinkPage):
     pass
+
 
 class ArticleListPage(RoutablePageMixin, Page):
     template = 'page.html'

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -11,10 +11,10 @@ from wagtailmenus import get_flat_menu_model, get_main_menu_model
 from wagtailmenus.tests.models import LinkPage
 try:
     from wagtail.admin.panels import ObjectList
-    from wagtail.models import Page, Site
+    from wagtail.models import Site
 except ImportError:
     from wagtail.admin.edit_handlers import ObjectList
-    from wagtail.core.models import Page, Site
+    from wagtail.core.models import Site
 
 FlatMenu = get_flat_menu_model()
 

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     from wagtail.core import hooks
 
+
 class TestHooks(TestCase):
     fixtures = ['test.json']
 

--- a/wagtailmenus/tests/test_mainmenu_class.py
+++ b/wagtailmenus/tests/test_mainmenu_class.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 
-from wagtailmenus.conf import constants
 from wagtailmenus.models import MainMenu
 from wagtailmenus.tests import base, utils
 
@@ -102,7 +101,6 @@ class TestGetPagesForDisplay(MainMenuTestCase):
         # accessing it again shouldn't trigger any database queries
         with self.assertNumQueries(0):
             list(menu.pages_for_display.values())
-
 
 
 class TestAddMenuItemsForPages(MainMenuTestCase):

--- a/wagtailmenus/tests/test_menu_items.py
+++ b/wagtailmenus/tests/test_menu_items.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from wagtailmenus.conf import settings
 from wagtailmenus.models import (
-    AbstractMenuItem, MainMenu, MainMenuItem, FlatMenu, FlatMenuItem
+    MainMenu, MainMenuItem, FlatMenu, FlatMenuItem
 )
 try:
     from wagtail.models import Page

--- a/wagtailmenus/tests/test_page_models.py
+++ b/wagtailmenus/tests/test_page_models.py
@@ -141,5 +141,3 @@ class TestLinkPage(TestCase):
             response,
             '/superheroes/marvel-comics/spiderman/?somevar=value'
         )
-
-

--- a/wagtailmenus/tests/utils.py
+++ b/wagtailmenus/tests/utils.py
@@ -1,6 +1,5 @@
 from django.template import RequestContext
 from django.test.client import RequestFactory
-from wagtailmenus.conf import constants
 from wagtailmenus.models.menus import ContextualVals, OptionVals
 
 

--- a/wagtailmenus/utils/tests/test_misc.py
+++ b/wagtailmenus/utils/tests/test_misc.py
@@ -1,5 +1,5 @@
 from django.test import RequestFactory, TestCase, modify_settings
-from distutils.version import LooseVersion
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtailmenus.conf import defaults
 from wagtailmenus.utils.misc import (
     derive_page, derive_section_root, get_fake_request, get_site_from_request
@@ -8,10 +8,8 @@ from wagtailmenus.tests.models import (
     ArticleListPage, ArticlePage, LowLevelPage, TopLevelPage
 )
 try:
-    from wagtail import __version__ as wagtail_version
     from wagtail.models import Page, Site
 except ImportError:
-    from wagtail.core import __version__ as wagtail_version
     from wagtail.core.models import Page, Site
 
 
@@ -272,7 +270,7 @@ class TestGetSiteFromRequest(TestCase):
         # URL to request during test
         self.url = '/superheroes/marvel-comics/'
         # Establish if Wagtail is v2.9 or above
-        if LooseVersion(wagtail_version) >= LooseVersion('2.9'):
+        if WAGTAIL_VERSION >= (2, 9):
             self.is_wagtail_29_or_above = True
         else:
             self.is_wagtail_29_or_above = False

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -6,18 +6,16 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin import messages
 from wagtail.contrib.modeladmin.views import (
     WMABaseView, CreateView, EditView, ModelFormView
 )
 from wagtailmenus.conf import settings
-from distutils.version import LooseVersion
 try:
-    from wagtail import __version__ as wagtail_version
     from wagtail.models import Site
     from wagtail.admin.panels import ObjectList, TabbedInterface
 except ImportError:
-    from wagtail.core import __version__ as wagtail_version
     from wagtail.core.models import Site
     from wagtail.admin.edit_handlers import ObjectList, TabbedInterface
 
@@ -60,8 +58,8 @@ class MenuTabbedInterfaceMixin:
                 ObjectList(self.model.settings_panels, heading=_("Settings"),
                            classname="settings"),
             ])
-        if LooseVersion(wagtail_version) < LooseVersion('3.0'):
-            # For Wagtail>=2.5,<3.0
+        if WAGTAIL_VERSION < (3, 0):
+            # For Wagtail>=2.15,<3.0
             return edit_handler.bind_to(model=self.model)
         return edit_handler.bind_to_model(self.model)
 


### PR DESCRIPTION
### This PR fixes some warnings and does the following:
- Removed usage of the deprecated distutils.
- Added new variables in settings to suppress warnings.
- Fixed formatting, removed unused imports.
- Updated workflow action versions.
- Updated documentation.

### Testing
- Tests pass
- There are some remaining warnings with regards to models.

```
Found 175 test(s).
Creating test database for alias 'default'...
System check identified some issues:

WARNINGS:
tests.LinkPage: (wagtailsearch.W001) Core Page fields missing in `search_fields`
        HINT: Ensure that LinkPage extends the Page model search fields `search_fields = Page.search_fields + [...]`
wagtailmenus.FlatMenu: (wagtailadmin.W002) FlatMenu.content_panels will have no effect on modeladmin editing
        HINT: Ensure that FlatMenu uses `panels` instead of `content_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Content tab for the content_panels to render in.
wagtailmenus.FlatMenu: (wagtailadmin.W002) FlatMenu.settings_panels will have no effect on modeladmin editing
        HINT: Ensure that FlatMenu uses `panels` instead of `settings_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Settings tab for the settings_panels to render in.
wagtailmenus.MainMenu: (wagtailadmin.W002) MainMenu.content_panels will have no effect on modeladmin editing
        HINT: Ensure that MainMenu uses `panels` instead of `content_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Content tab for the content_panels to render in.
wagtailmenus.MainMenu: (wagtailadmin.W002) MainMenu.settings_panels will have no effect on modeladmin editing
        HINT: Ensure that MainMenu uses `panels` instead of `settings_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Settings tab for the settings_panels to render in.

System check identified 5 issues (0 silenced).
...............................................................................................................................................................................
----------------------------------------------------------------------
Ran 175 tests in 15.778s

OK
Destroying test database for alias 'default'...
Name                                                                Stmts   Miss  Cover
---------------------------------------------------------------------------------------
wagtailmenus/__init__.py                                               17      4    76%
wagtailmenus/apps.py                                                    4      0   100%
wagtailmenus/conf/__init__.py                                           0      0   100%
wagtailmenus/conf/constants.py                                          2      0   100%
wagtailmenus/conf/defaults.py                                          30      0   100%
wagtailmenus/conf/settings.py                                           5      0   100%
wagtailmenus/conf/tests/__init__.py                                     0      0   100%
wagtailmenus/conf/tests/test_modeladmin_disable_settings.py            27      0   100%
wagtailmenus/context_processors.py                                     24      0   100%
wagtailmenus/development/__init__.py                                    0      0   100%
wagtailmenus/development/urls.py                                        9      9     0%
wagtailmenus/errors.py                                                  6      0   100%
wagtailmenus/forms.py                                                  13      0   100%
wagtailmenus/management/__init__.py                                     0      0   100%
wagtailmenus/management/commands/__init__.py                            0      0   100%
wagtailmenus/management/commands/autopopulate_main_menus.py            18      2    89%
wagtailmenus/managers.py                                                4      0   100%
wagtailmenus/migrations/0001_initial.py                                 6      0   100%
wagtailmenus/migrations/0002_auto_20160129_0901.py                      5      0   100%
wagtailmenus/migrations/0003_auto_20160129_2339.py                      5      0   100%
wagtailmenus/migrations/0004_auto_20160130_0024.py                      5      0   100%
wagtailmenus/migrations/0005_auto_20160130_2209.py                      5      0   100%
wagtailmenus/migrations/0006_auto_20160131_1347.py                      5      0   100%
wagtailmenus/migrations/0007_auto_20160131_2000.py                      5      0   100%
wagtailmenus/migrations/0008_auto_20160131_2327.py                      5      0   100%
wagtailmenus/migrations/0009_auto_20160201_0859.py                      5      0   100%
wagtailmenus/migrations/0010_auto_20160201_1558.py                      5      0   100%
wagtailmenus/migrations/0011_auto_20160415_1519.py                      5      0   100%
wagtailmenus/migrations/0012_auto_20160419_0039.py                      6      0   100%
wagtailmenus/migrations/0013_auto_20160423_1124.py                      5      0   100%
wagtailmenus/migrations/0014_auto_20160423_1339.py                      5      0   100%
wagtailmenus/migrations/0015_auto_20160423_1348.py                      5      0   100%
wagtailmenus/migrations/0016_auto_20160930_0645.py                      5      0   100%
wagtailmenus/migrations/0017_auto_20161013_1658.py                      6      0   100%
wagtailmenus/migrations/0018_auto_20161204_2043.py                      5      0   100%
wagtailmenus/migrations/0019_auto_20161204_2143.py                      5      0   100%
wagtailmenus/migrations/0020_auto_20161210_0004.py                      6      0   100%
wagtailmenus/migrations/0021_auto_20170106_2352.py                      5      0   100%
wagtailmenus/migrations/0022_auto_20170913_2125.py                      5      0   100%
wagtailmenus/migrations/0023_remove_use_specific.py                     4      0   100%
wagtailmenus/migrations/__init__.py                                     0      0   100%
wagtailmenus/modeladmin.py                                             70      1    99%
wagtailmenus/models/__init__.py                                         3      0   100%
wagtailmenus/models/menuitems.py                                       85      7    92%
wagtailmenus/models/menus.py                                          549     15    97%
wagtailmenus/models/mixins.py                                          42      0   100%
wagtailmenus/models/pages.py                                          124      7    94%
wagtailmenus/panels.py                                                 31      2    94%
wagtailmenus/settings/__init__.py                                       0      0   100%
wagtailmenus/settings/base.py                                          22      0   100%
wagtailmenus/settings/development.py                                    9      9     0%
wagtailmenus/settings/testing.py                                       11      0   100%
wagtailmenus/templatetags/__init__.py                                   0      0   100%
wagtailmenus/templatetags/menu_tags.py                                 61      2    97%
wagtailmenus/tests/__init__.py                                          0      0   100%
wagtailmenus/tests/base.py                                             70      2    97%
wagtailmenus/tests/migrations/0001_initial.py                           7      0   100%
wagtailmenus/tests/migrations/0002_homepage.py                          6      0   100%
wagtailmenus/tests/migrations/0003_auto_20160418_1204.py                5      0   100%
wagtailmenus/tests/migrations/0004_auto_20160419_2022.py                5      0   100%
wagtailmenus/tests/migrations/0005_auto_20160419_2025.py                5      0   100%
wagtailmenus/tests/migrations/0006_auto_20160423_1339.py                5      0   100%
wagtailmenus/tests/migrations/0007_auto_20160423_1348.py                5      0   100%
wagtailmenus/tests/migrations/0008_contactpage.py                       6      0   100%
wagtailmenus/tests/migrations/0009_typicalpage.py                       6      0   100%
wagtailmenus/tests/migrations/0010_auto_20161211_2116.py                9      0   100%
wagtailmenus/tests/migrations/0011_auto_20170106_2355.py                5      0   100%
wagtailmenus/tests/migrations/0012_linkpage.py                          6      0   100%
wagtailmenus/tests/migrations/0013_auto_20170630_1002.py                5      0   100%
wagtailmenus/tests/migrations/0014_noabsoluteurlspage.py                6      0   100%
wagtailmenus/tests/migrations/0015_remove_use_specific.py               4      0   100%
wagtailmenus/tests/migrations/0016_articlelistpage_articlepage.py       6      0   100%
wagtailmenus/tests/migrations/__init__.py                               0      0   100%
wagtailmenus/tests/modeladmin.py                                        5      5     0%
wagtailmenus/tests/models/__init__.py                                   2      0   100%
wagtailmenus/tests/models/menus.py                                     38      2    95%
wagtailmenus/tests/models/pages.py                                    111      5    95%
wagtailmenus/tests/models/utils.py                                     13      0   100%
wagtailmenus/tests/test_backend.py                                    150      3    98%
wagtailmenus/tests/test_base_menu_classes.py                           44      2    95%
wagtailmenus/tests/test_childrenmenu_class.py                          11      0   100%
wagtailmenus/tests/test_commands.py                                    35      2    94%
wagtailmenus/tests/test_custom_models.py                              107      0   100%
wagtailmenus/tests/test_flatmenu_class.py                              46      0   100%
wagtailmenus/tests/test_hooks.py                                       61      4    93%
wagtailmenus/tests/test_mainmenu_class.py                              87      1    99%
wagtailmenus/tests/test_menu_class.py                                  48      0   100%
wagtailmenus/tests/test_menu_items.py                                  83      2    98%
wagtailmenus/tests/test_menu_rendering.py                             252      2    99%
wagtailmenus/tests/test_page_models.py                                 69      2    97%
wagtailmenus/tests/test_sectionmenu_class.py                           16      0   100%
wagtailmenus/tests/test_test_page_models.py                            27      0   100%
wagtailmenus/tests/urls.py                                              6      0   100%
wagtailmenus/tests/utils.py                                            26      4    85%
wagtailmenus/utils/__init__.py                                          0      0   100%
wagtailmenus/utils/deprecation.py                                       5      5     0%
wagtailmenus/utils/inspection.py                                        9      9     0%
wagtailmenus/utils/misc.py                                             74      5    93%
wagtailmenus/utils/tests/__init__.py                                    0      0   100%
wagtailmenus/utils/tests/test_misc.py                                 114      3    97%
wagtailmenus/utils/version.py                                          13      2    85%
wagtailmenus/views.py                                                 121      4    97%
wagtailmenus/wagtail_hooks.py                                          15      2    87%
---------------------------------------------------------------------------------------
TOTAL                                                                3033    124    96%
```