### PR TITLE
👌 IMPROVE: Set default_auto_field explicitly

### DIFF
--- a/wagtailmenus/apps.py
+++ b/wagtailmenus/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class WagtailMenusConfig(AppConfig):
     name = 'wagtailmenus'
     verbose_name = 'WagtailMenus'
+    default_auto_field = "django.db.models.AutoField"

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -44,7 +44,7 @@ def main_menu(
 
 @register.simple_tag(takes_context=True)
 def flat_menu(
-    context, handle, max_levels=None, show_menu_heading=False,
+    context, handle, max_levels=None, show_menu_heading=True,
     apply_active_classes=False, allow_repeating_parents=True,
     show_multiple_levels=True, template='', sub_menu_template='',
     sub_menu_templates=None, fall_back_to_default_site_menus=None,


### PR DESCRIPTION
Fixes #452 and #435 

Sets DEFAULT_AUTO_FIELD explicitly to use the 'django.db.models.AutoField' field.