### PR TITLE
Independent wagtail_modeladmin support for Wagtail 5.1

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,13 +4,14 @@
 Installing wagtailmenus
 =========================
 
-1.  Install the package using pip:
+1.  Install packages using pip:
 
     .. code-block:: console
 
         pip install wagtailmenus
+        pip install wagtail_modeladmin  # if Wagtail >= 5.1
 
-2.  Add ``wagtailmenus`` and ``wagtail.contrib.modeladmin`` to the
+2.  Add ``wagtailmenus`` and ``modeladmin`` to the
     ``INSTALLED_APPS`` setting in your project settings:
 
     .. code-block:: python
@@ -18,7 +19,8 @@ Installing wagtailmenus
 
         INSTALLED_APPS = [
             ...
-            'wagtail.contrib.modeladmin',  # Don't repeat if it's there already
+            'wagtail_modeladmin',          # if Wagtail >=5.1; Don't repeat if it's there already
+            'wagtail.contrib.modeladmin',  # if Wagtail <5.1;  Don't repeat if it's there already
             'wagtailmenus',
         ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ testing_extras = [
 
 development_extras = [
     'wagtail>=2.15',
+    'wagtail_modeladmin>=1.0',
     'django-debug-toolbar',
     'django-extensions',
     'ipdb',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
     py{38,39,310}-dj{40}-wt{41,42}
     py{38,39,310}-dj{32,41}-wt{41,42,50}
     py{311}-dj{41}-wt{41,42,50}
-    py{311}-dj{42}-wt{50}
+    py{38,39,310,311}-dj{41,42}-wt{51}-wma{10}
 
 [gh-actions]
 python =
@@ -23,6 +23,7 @@ commands = coverage run --source=wagtailmenus runtests.py
 
 deps =
     coverage
+    wma10: wagtail_modeladmin>=1.0,<1.1
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
@@ -30,3 +31,4 @@ deps =
     wt41: wagtail>=4.1,<4.2
     wt42: wagtail>=4.2,<5.0
     wt50: wagtail>=5.0,<5.1
+    wt51: wagtail>=5.1,<5.2

--- a/wagtailmenus/conf/tests/test_modeladmin_disable_settings.py
+++ b/wagtailmenus/conf/tests/test_modeladmin_disable_settings.py
@@ -6,12 +6,18 @@ from django.test import TestCase, override_settings
 from wagtailmenus import wagtail_hooks
 from wagtailmenus.modeladmin import FlatMenuAdmin, MainMenuAdmin
 
+try:
+    from wagtail_modeladmin.options import modeladmin_register
+    modeladmin_register_str = 'wagtail_modeladmin.options.modeladmin_register'
+except ModuleNotFoundError:
+    from wagtail.contrib.modeladmin.options import modeladmin_register
+    modeladmin_register_str = 'wagtail.contrib.modeladmin.options.modeladmin_register'
 
 class TestDisablingFlatMenusInWagtailCMS(TestCase):
     """
     Tests if modeladmin is registered based on settings.
     """
-    @patch('wagtail.contrib.modeladmin.options.modeladmin_register')
+    @patch(modeladmin_register_str)
     def test_modeladmin_registered_by_default(self, mock_modeladmin_register):
         reload(wagtail_hooks)
         self.assertIn(
@@ -22,7 +28,7 @@ class TestDisablingFlatMenusInWagtailCMS(TestCase):
     @override_settings(
         WAGTAILMENUS_FLAT_MENUS_EDITABLE_IN_WAGTAILADMIN=False,
     )
-    @patch('wagtail.contrib.modeladmin.options.modeladmin_register')
+    @patch(modeladmin_register_str)
     def test_modeladmin_not_registered_if_disabled(self, mock_modeladmin_register):
         """
         Disabling the 'Flat menu' via setting should prevent registering the
@@ -38,7 +44,7 @@ class TestDisablingFlatMenusInWagtailCMS(TestCase):
 
 class TestDisablingMainMenusInWagtailCMS(TestCase):
 
-    @patch('wagtail.contrib.modeladmin.options.modeladmin_register')
+    @patch(modeladmin_register_str)
     def test_modeladmin_registered_by_default(self, mock_modeladmin_register):
         reload(wagtail_hooks)
         self.assertIn(
@@ -49,7 +55,7 @@ class TestDisablingMainMenusInWagtailCMS(TestCase):
     @override_settings(
         WAGTAILMENUS_MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN=False,
     )
-    @patch('wagtail.contrib.modeladmin.options.modeladmin_register')
+    @patch(modeladmin_register_str)
     def test_disable_main_menus(self, mock_modeladmin_register):
         """
         Disabling the 'Main menu' via setting should prevent registering the

--- a/wagtailmenus/modeladmin.py
+++ b/wagtailmenus/modeladmin.py
@@ -2,8 +2,12 @@ from django.contrib.admin.utils import quote
 from django.urls import re_path
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from wagtail.contrib.modeladmin.helpers import ButtonHelper
-from wagtail.contrib.modeladmin.options import ModelAdmin
+try:
+    from wagtail_modeladmin.helpers import ButtonHelper
+    from wagtail_modeladmin.options import ModelAdmin
+except ModuleNotFoundError:
+    from wagtail.contrib.modeladmin.helpers import ButtonHelper
+    from wagtail.contrib.modeladmin.options import ModelAdmin
 
 from wagtailmenus import views
 from wagtailmenus.conf import settings

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -1,5 +1,7 @@
 import os
 
+import wagtail
+
 DEBUG = True
 SITE_ID = 1
 
@@ -10,7 +12,7 @@ USE_L10N = True
 LANGUAGE_CODE = 'en'
 
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'wagtailmenus',
 
     'taggit',
@@ -35,9 +37,12 @@ INSTALLED_APPS = (
     'wagtail.contrib.redirects',
     'wagtail.contrib.routable_page',
     'wagtail.contrib.settings',
-    'wagtail.contrib.modeladmin',
+]
 
-)
+if wagtail.VERSION >= (5, 1):
+    INSTALLED_APPS += ['wagtail_modeladmin']
+else:
+    INSTALLED_APPS += ['wagtail.contrib.modeladmin']
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -8,8 +8,12 @@ from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.panels import ObjectList, TabbedInterface
-from wagtail.contrib.modeladmin.views import (CreateView, EditView,
-                                              ModelFormView, WMABaseView)
+try:
+    from wagtail_modeladmin.views import (CreateView, EditView,
+                                          ModelFormView, WMABaseView)
+except ModuleNotFoundError:
+    from wagtail.contrib.modeladmin.views import (CreateView, EditView,
+                                                  ModelFormView, WMABaseView)
 from wagtail.models import Site
 
 from wagtailmenus.conf import settings

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -1,5 +1,8 @@
 from wagtail import hooks
-from wagtail.contrib.modeladmin.options import modeladmin_register
+try:
+    from wagtail_modeladmin.options import modeladmin_register
+except ModuleNotFoundError:
+    from wagtail.contrib.modeladmin.options import modeladmin_register
 
 from wagtailmenus.conf import settings
 from wagtailmenus.utils.misc import derive_section_root


### PR DESCRIPTION
This PR extend compatibility of `wagtailmenus` to Wagtail 5.1 and particularly supports the newly independent `wagtail_modeladmin` module in lieu of the previous `wagtail.contrib.modeladmin` module.

This is a stop-gap measure to provide clean support for Wagtail 5.1 while a more permanent Snippet-based solution is developed. There is no change in functionality. Tests have been extended to Wagtail 5.1 and all pass. Packaging and documentation have also been updated.

See #459 for discussion.
