### PR TITLE
fix: add wagtail-modeladmin as dependency

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,7 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to
 * Gabriel Augendre (Crocmagnon)
 * Bojan Mihelac (bmihelac)
 * Ben Froelich-Leon (benfroelich)
+* Malte Gerth
 
 ## Translators
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ branch_url = "%stree/stable/%s" % (base_url, stable_branch_name)
 # Essential dependencies
 requires = [
     'django-cogwheels==0.3',
+    'wagtail-modeladmin>=1.0.0',
 ]
 
 testing_extras = [


### PR DESCRIPTION
this is just a quick fix for https://github.com/jazzband/wagtailmenus/issues/459

The project should migrate to use wagtail snippets instead.