### PR TITLE
Silence errors by renaming panels on models

### DIFF
--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1045,7 +1045,7 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         data.update(kwargs)
         return super().get_context_data(**data)
 
-    settings_panels = panels.menu_settings_panels
+    s_panels = panels.menu_settings_panels
 
 
 # ########################################################
@@ -1056,7 +1056,7 @@ class AbstractMainMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
     menu_short_name = 'main'  # used to find templates
     menu_instance_context_name = 'main_menu'
     related_templatetag_name = 'main_menu'
-    content_panels = panels.main_menu_content_panels
+    c_panels = panels.main_menu_content_panels
     menu_items_relation_setting_name = 'MAIN_MENU_ITEMS_RELATED_NAME'
 
     site = models.OneToOneField(
@@ -1132,7 +1132,7 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
     menu_instance_context_name = 'flat_menu'
     related_templatetag_name = 'flat_menu'
     base_form_class = forms.FlatMenuAdminForm
-    content_panels = panels.flat_menu_content_panels
+    c_panels = panels.flat_menu_content_panels
     menu_items_relation_setting_name = 'FLAT_MENU_ITEMS_RELATED_NAME'
 
     site = models.ForeignKey(

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -128,7 +128,7 @@ class MenuPageMixin(models.Model):
 
 class MenuPage(Page, MenuPageMixin):
 
-    settings_panels = menupage_settings_panels
+    s_panels = menupage_settings_panels
 
     class Meta:
         abstract = True

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -82,7 +82,7 @@ class FlatMenuCustomMenuItem(MultilingualMenuItem, AbstractFlatMenuItem):
 
 
 class CustomMainMenu(AbstractMainMenu):
-    panels = AbstractMainMenu.content_panels + AbstractMainMenu.settings_panels
+    panels = AbstractMainMenu.c_panels + AbstractMainMenu.s_panels
 
 
 class CustomFlatMenu(AbstractFlatMenu):
@@ -100,7 +100,7 @@ class CustomFlatMenu(AbstractFlatMenu):
         'heading', 'heading_de', 'heading_fr'
     )
 
-    content_panels = (
+    c_panels = (
         MultiFieldPanel(
             heading="Settings",
             children=(
@@ -118,7 +118,7 @@ class CustomFlatMenu(AbstractFlatMenu):
             ),
             classname='collapsible'
         ),
-        AbstractFlatMenu.content_panels[1],
+        AbstractFlatMenu.c_panels[1],
     )
 
 

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -71,7 +71,7 @@ class MultilingualMenuPage(MenuPage):
         item.text = self.translated_repeated_item_text or self.translated_title
         return item
 
-    settings_panels = [
+    s_panels = [
         PublishingPanel(),
         MultiFieldPanel(
             heading="Advanced menu behaviour",

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -172,12 +172,12 @@ class TestSuperUser(TransactionTestCase):
 
         # Set 'panels' attribute on menu model to increase coverage for
         # MenuTabbedInterfaceMixin.get_edit_handler_class()
-        menu_model.panels = menu_model.content_panels
+        menu_model.panels = menu_model.c_panels
         response = self.client.get('/admin/wagtailmenus/mainmenu/edit/1/')
 
         # Set 'edit_handler' attribute on menu model to increase coverage for
         # MenuTabbedInterfaceMixin.get_edit_handler_class()
-        menu_model.edit_handler = ObjectList(menu_model.content_panels)
+        menu_model.edit_handler = ObjectList(menu_model.c_panels)
         response = self.client.get('/admin/wagtailmenus/mainmenu/edit/1/')
 
     def test_mainmenu_edit_multisite(self):

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -53,8 +53,8 @@ class MenuTabbedInterfaceMixin:
             edit_handler = ObjectList(self.model.panels)
         else:
             edit_handler = TabbedInterface([
-                ObjectList(self.model.content_panels, heading=_("Content")),
-                ObjectList(self.model.settings_panels, heading=_("Settings"),
+                ObjectList(self.model.c_panels, heading=_("Content")),
+                ObjectList(self.model.s_panels, heading=_("Settings"),
                            classname="settings"),
             ])
         return edit_handler.bind_to_model(self.model)


### PR DESCRIPTION
When `wagtailmenus` is used on our sites, we usually encounter these warnings:

```
wagtailmenus.FlatMenu: (wagtailadmin.W002) FlatMenu.content_panels will have no effect on modeladmin editing
        HINT: Ensure that FlatMenu uses `panels` instead of `content_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Content tab for the content_panels to render in.
wagtailmenus.FlatMenu: (wagtailadmin.W002) FlatMenu.settings_panels will have no effect on modeladmin editing
        HINT: Ensure that FlatMenu uses `panels` instead of `settings_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Settings tab for the settings_panels to render in.
wagtailmenus.MainMenu: (wagtailadmin.W002) MainMenu.content_panels will have no effect on modeladmin editing
        HINT: Ensure that MainMenu uses `panels` instead of `content_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Content tab for the content_panels to render in.
wagtailmenus.MainMenu: (wagtailadmin.W002) MainMenu.settings_panels will have no effect on modeladmin editing
        HINT: Ensure that MainMenu uses `panels` instead of `settings_panels`or set up an `edit_handler` if you want a tabbed editing interface.
There are no default tabs on non-Page models so there will be no Settings tab for the settings_panels to render in.
```

even though [edit_handler IS being used on the mixin used by views correctly](https://github.com/jazzband/wagtailmenus/blob/master/wagtailmenus/views.py#L47), just because the class variables in the internal models are in [this wagtail admin model check](https://github.com/wagtail/wagtail/blob/main/wagtail/admin/checks.py#L133).

I find that renaming the class variables like so in wagtailmenus silences the warnings