### PR TITLE
ModelAdmin to Snippets Documentation Update

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,8 @@ wagtailmenus is an open-source extension for `Wagtail CMS
 
 The current version is tested for compatibility with the following:
 
-- Wagtail versions >= 4.1
-- Django versions 3.2, 4.1, and 4.2
+- Wagtail versions >= 5.2
+- Django versions 3.2, 4.2 and >= 5.0
 - Python versions 3.8 to 3.12
 
 To find out more about what wagtailmenus does and why, see :doc:`overview`

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ Installing wagtailmenus
 
         pip install wagtailmenus
 
-2.  Add ``wagtailmenus`` and ``modeladmin`` to the
+2.  Add ``wagtailmenus`` to the
     ``INSTALLED_APPS`` setting in your project settings:
 
     .. code-block:: python

--- a/docs/source/releases/4.0.rst
+++ b/docs/source/releases/4.0.rst
@@ -1,0 +1,55 @@
+==============================
+Wagtailmenus 4.0 release notes
+==============================
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new?
+===========
+
+Wagtailmenus now uses Snippets
+------------------------------
+
+Wagtailmenus prior to this release used the Wagtail ModelAdmin contrib package for menu administration.
+With the deprecation of ModelAdmin in Wagtail 5.2 and its removal in Wagtail 6, Wagtail's enhanced Snippet capability is now used for menu admin.
+
+This release retains all the functionality of wagtailmenus 3.1.9, however the admin user interface has changed consistent with the revised look in Wagtail 5.2 and 6.
+Any existing menu configuration is retained.
+
+Upgrade considerations
+======================
+
+Migration from ModelAdmin to Snippets
+-------------------------------------
+
+The two menu administration ViewSets, ``MainMenuAdmin`` and ``FlatMenuAdmin``, are now based on ``SnippetViewSet``.
+
+Ensure wagtail.snippets is in your INSTALLED_APPS:
+
+.. code-block:: python
+
+    INSTALLED_APPS = [
+        ...,
+        'wagtail.snippets',
+        ...,
+    ]
+
+If `wagtailmenus` is your code's last dependency on `ModelAdmin`,
+then you can remove `wagtail_modeladmin` or `wagtail.contrib.modeladmin` from your `INSTALLED_APPS` and if present, from your `requirements.txt` file.
+
+Customised Admin Classes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have customised either of ``MainMenuAdmin`` and ``FlatMenuAdmin``,
+you will need to refactor your code to be compatible with ``SnippetViewSet`` behaviour.
+The guide at `Migrating from ModelAdmin to Snippets <https://docs.wagtail.org/en/v5.2.3/reference/contrib/modeladmin/migrating_to_snippets.html>`_ in the Wagtail documentation may assist with this task.
+
+You will need to assign the newly customised admin classes to the following settings:
+
+- ``WAGTAILMENUS_MAIN_MENUS_ADMIN_CLASS``. This replaces ``WAGTAILMENUS_MAIN_MENUS_MODELADMIN_CLASS``
+- ``WAGTAILMENUS_FLAT_MENUS_ADMIN_CLASS``. This replaces ``WAGTAILMENUS_FLAT_MENUS_MODELADMIN_CLASS``
+
+Note that ``MainMenuAdmin`` and ``FlatMenuAdmin`` are now in the ``wagtailmenus.menuadmin`` module, and that the ``wagtailmenus.modeladmin`` module has been removed.

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    4.0
     3.1.9
     3.1.8
     3.1.7


### PR DESCRIPTION
This is a continuation of https://github.com/jazzband/wagtailmenus/pull/472 to address https://github.com/jazzband/wagtailmenus/issues/459.

In particular, this adds documentation including initial release notes for a 4.0 release.

I believe I've found and modified anything relating to the move from ModelAdmin to Snippets, but a review looking for any missed changes would be appreciated.

TODO: in this or another PR, update the images in the documentation, which are mostly Wagtail 2 era screenshots.