### PR TITLE
Update tox test matrix for Wagtail 6.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     wt60-dj42-py{38,39,310,311,312}
     wt60-dj50-py{310,311,312}
     wt61-dj{42,50}-py{310,311,312}
+    wt62-dj{42,50}-py{310,311,312}
 
 [gh-actions]
 python =
@@ -33,3 +34,4 @@ deps =
     wt52: wagtail>=5.2,<5.3
     wt60: wagtail>=6.0,<6.1
     wt61: wagtail>=6.1,<6.2
+    wt62: wagtail>=6.2,<6.3


### PR DESCRIPTION
While I was testing the package for Wagtail 6.2 I made the changes here to the testing matrix.

I could see any other changes were needed.