### PR TITLE
Bump version to 4.0.2 and update release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 Changelog
 =========
 
-Unreleased
-==========
+4.0.1 (02.01.2025)
+----------
 
-- Update the testing environment to test Wagtail 6.3 and Django 5.1
-- Add conditional support for Wagtail 6.3 templates
+* Update the testing environment to test Wagtail 6.3 and Django 5.1
+* Add conditional support for Wagtail 6.3 templates.
+* Fix Italian translation [#499](github.com/jazzband/wagtailmenus/pull/499).
 
 4.0.1 (04.08.2024)
 ----------

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,7 @@ This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to
 * Bojan Mihelac (bmihelac)
 * Ben Froelich-Leon (benfroelich)
 * Daniel Kirkham (dkirkham)
+* Nick Moreton (nickmoreton)
 
 ## Translators
 

--- a/docs/source/releases/4.0.1.rst
+++ b/docs/source/releases/4.0.1.rst
@@ -1,0 +1,19 @@
+===============================================
+Wagtailmenus 4.0.1 release notes (04.08.2024)
+===============================================
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new?
+===========
+
+There are no new major features in this release.
+
+Minor changes & bug fixes
+=========================
+
+* Fix German translation.
+* Fix `bs4.FeatureNotFound` error on tests.

--- a/docs/source/releases/4.0.2.rst
+++ b/docs/source/releases/4.0.2.rst
@@ -1,0 +1,21 @@
+===============================================
+Wagtailmenus 4.0.2 release notes (02.01.2025)
+===============================================
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new?
+===========
+
+There are no new major features in this release.
+
+Minor changes & bug fixes
+=========================
+
+* Added support for Wagtail 6.3.
+* Added support for Django 5.1.
+* Added "Python 3.13" to the list of PyPI classifiers.
+* Fix Italian translation [#499](github.com/jazzband/wagtailmenus/pull/499).

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,8 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    4.0.2
+    4.0.1
     4.0
     3.1.9
     3.1.8

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -2,7 +2,7 @@ from wagtailmenus.utils.version import get_stable_branch_name, get_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (4, 0, 1, "final", 0)
+VERSION = (4, 0, 2, "final", 0)
 __version__ = get_version(VERSION)
 stable_branch_name = get_stable_branch_name(VERSION)
 

--- a/wagtailmenus/locale/ar/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/ar/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Arabic (https://www.transifex.com/rkhleics/teams/73023/ar/)\n"
@@ -62,30 +62,30 @@ msgstr "بشكل افتراضي ، سيتم استخدام هذا كنص ارت�
 msgid "Main menu"
 msgstr "القائمة الرئيسية"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "لا يمكن حفظ القائمة بسبب الأخطاء."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "يحتوى"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "الإعدادات"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "لا يمكن حفظ القائمة بسبب الأخطاء."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "القوائم المسطحة"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -311,11 +311,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "تحرير %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/de/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/de/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: German (https://www.transifex.com/rkhleics/teams/73023/de/)\n"
@@ -62,30 +62,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Hauptmenü"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Das Menü konnte aufgrund von Fehlern nicht gespeichert werden."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Inhalt"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Das Menü konnte aufgrund von Fehlern nicht gespeichert werden."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Flache Menüs"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -312,11 +312,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Bearbeite %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/en/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -54,28 +54,28 @@ msgstr ""
 msgid "Main menu"
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 msgid "The flat menu could not be saved due to errors"
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr ""
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 msgid "The flat menu could not be saved due to errors."
 msgstr ""
 
@@ -277,11 +277,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr ""
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr ""
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/es_419/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/es_419/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 22:03+0100\n"
+"POT-Creation-Date: 2025-01-02 16:42+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Spanish (Latin America) (https://www.transifex.com/rkhleics/"
@@ -63,30 +63,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Menú principal"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "El menú no pudo ser guardado debido a errores."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Contenido"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Ajustes"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "El menú no pudo ser guardado debido a errores."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Menús planos"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -315,11 +315,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Editando %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/fr/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/fr/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: French (https://www.transifex.com/rkhleics/teams/73023/fr/)\n"
@@ -63,30 +63,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Menu principal"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Ce menu ne peut pas être enregistré, des erreurs subsistent."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Contenu"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Configuration"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Ce menu ne peut pas être enregistré, des erreurs subsistent."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Menu additionnel"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -317,11 +317,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Modification de %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/id/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/id/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: wagtailmenus 3.1.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Kira <kiraware@github.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,30 +58,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Menu utama"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Menu tidak dapat disimpan karena kesalahan."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Konten"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Pengaturan"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Menu tidak dapat disimpan karena kesalahan."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Menu datar"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -309,11 +309,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Mengedit %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/it/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/it/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Italian (https://www.transifex.com/rkhleics/teams/73023/it/)\n"
@@ -58,28 +58,28 @@ msgstr "Questo è il testo di collegamento predefinito usato nei menù."
 msgid "Main menu"
 msgstr "Menù principale"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Non è stato possibile salvare il menù a seguito di errori."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Contenuto"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 msgid "The flat menu could not be saved due to errors"
 msgstr "Non è stato possibile salvare il menù piatto a seguito di errori."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Menù piatti"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 msgid "The flat menu could not be saved due to errors."
 msgstr "Non è stato possibile salvare il menù piatto a seguito di errori."
 
@@ -278,7 +278,9 @@ msgstr ""
 
 #: wagtailmenus/models/pages.py:201
 msgid "A link page cannot link to another link page"
-msgstr "Un collegamento di pagina non può referenziare un altro collegamento di pagina."
+msgstr ""
+"Un collegamento di pagina non può referenziare un altro collegamento di "
+"pagina."
 
 #: wagtailmenus/models/pages.py:289 wagtailmenus/models/pages.py:299
 #, python-format
@@ -307,11 +309,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr ""
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Modifica %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr "Azioni"

--- a/wagtailmenus/locale/lt/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/lt/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Lithuanian (https://www.transifex.com/rkhleics/teams/73023/"
@@ -66,30 +66,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Pagrindinis meniu"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Meniu negalėjo būti išsaugotas dėl klaidų."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Turinys"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Nustatymai"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Meniu negalėjo būti išsaugotas dėl klaidų."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Plokšti meniu"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -314,11 +314,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Redaguojama %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/nl/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/nl/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2023-11-12 17:54+0100\n"
 "Last-Translator: Maarten Ureel <maarten@youreal.eu>\n"
 "Language-Team: \n"
@@ -63,30 +63,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Hoofdmenu"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Het menu kon niet worden opgeslagen vanwege fouten."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Inhoud"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Instellingen"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Het menu kon niet worden opgeslagen vanwege fouten."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Platte menu's"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -320,11 +320,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Bewerken  %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/pt_BR/LC_MESSAGES/django.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/rkhleics/"
@@ -63,30 +63,30 @@ msgstr "Por padrão, esse será o texto do link usado quando aparecer em menus."
 msgid "Main menu"
 msgstr "Menu principal"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "O menu não pode ser salvo por conta de erros."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Conteúdo"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Configurações"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "O menu não pode ser salvo por conta de erros."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Menus simples"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -314,11 +314,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Editando %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr "Ações"

--- a/wagtailmenus/locale/ru/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/ru/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Russian (https://www.transifex.com/rkhleics/teams/73023/ru/)\n"
@@ -65,30 +65,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Главное меню"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Меню не может быть сохранено из-за ошибок."
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Содержимое"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Настройки"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Меню не может быть сохранено из-за ошибок."
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Плоские меню"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -318,11 +318,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Редактирование %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/uk/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/uk/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2023-11-13 11:38+2\n"
 "Last-Translator: Yaroslav Prykhodko <yarick.prih2903@hotmail.com>\n"
 "Language-Team: Ukrainian <LL@li.org>\n"
@@ -62,30 +62,30 @@ msgstr ""
 msgid "Main menu"
 msgstr "Головне меню"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "Не вдалося зберегти меню через помилки"
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "Контент"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "Налаштування"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "Не вдалося зберегти меню через помилки"
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "Плоскі меню"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -314,11 +314,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr "%(snippet_type_name_plural)s"
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "Редагування %(snippet_type_name)s - %(object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""

--- a/wagtailmenus/locale/zh_CN/LC_MESSAGES/django.po
+++ b/wagtailmenus/locale/zh_CN/LC_MESSAGES/django.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-24 21:55+0100\n"
+"POT-Creation-Date: 2025-01-02 16:38+0000\n"
 "PO-Revision-Date: 2017-03-20 23:04+0000\n"
 "Last-Translator: Andy Babic, 2018\n"
 "Language-Team: Chinese (China) (https://www.transifex.com/rkhleics/"
@@ -62,30 +62,30 @@ msgstr "默认情况下，这将用作菜单中显示的链接文本。"
 msgid "Main menu"
 msgstr "主菜单"
 
-#: wagtailmenus/menuadmin.py:91
+#: wagtailmenus/menuadmin.py:93
 msgid "The menu could not be saved due to errors."
 msgstr "出现错误，无法保存菜单。"
 
-#: wagtailmenus/menuadmin.py:94 wagtailmenus/menuadmin.py:147
+#: wagtailmenus/menuadmin.py:98 wagtailmenus/menuadmin.py:151
 msgid "Content"
 msgstr "内容"
 
-#: wagtailmenus/menuadmin.py:95 wagtailmenus/menuadmin.py:148
+#: wagtailmenus/menuadmin.py:99 wagtailmenus/menuadmin.py:152
 #: wagtailmenus/panels.py:87
 msgid "Settings"
 msgstr "设置"
 
-#: wagtailmenus/menuadmin.py:127
+#: wagtailmenus/menuadmin.py:131
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors"
 msgstr "出现错误，无法保存菜单。"
 
-#: wagtailmenus/menuadmin.py:132
+#: wagtailmenus/menuadmin.py:136
 msgid "Flat menus"
 msgstr "扁平化菜单"
 
-#: wagtailmenus/menuadmin.py:144
+#: wagtailmenus/menuadmin.py:148
 #, fuzzy
 #| msgid "The menu could not be saved due to errors."
 msgid "The flat menu could not be saved due to errors."
@@ -298,11 +298,12 @@ msgid "%(snippet_type_name_plural)s"
 msgstr ""
 
 #: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:3
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:3
 #, python-format
 msgid "Editing %(snippet_type_name)s - %(object)s"
 msgstr "编辑%(snippet_type_name)s - % (object)s"
 
-#: wagtailmenus/templates/wagtailmenus/mainmenu_edit.html:19
+#: wagtailmenus/templates/wagtailmenus/wagtail_before_63/mainmenu_edit.html:19
 #: wagtailmenus/templates/wagtailsnippets/snippets/copy.html:19
 msgid "Actions"
 msgstr ""


### PR DESCRIPTION
Update the version to 4.0.2, add release notes for this version, and fix missing release notes for 4.0.1. 

Bonus:
- Update source translation files
- Add Python 3.13 to PyPI classifiers