### PR TITLE
Update tested versions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ wagtailmenus is an extension for Torchbox's `Wagtail CMS <https://github.com/tor
 
 The current version is tested for compatibility with the following:
 
-- Wagtail versions >= 5.2
-- Django versions 4.2, 5.0 and >= 5.1
+- Wagtail versions <= 5.2
+- Django versions 4.2, 5.0 and <= 5.1
 - Python versions 3.9 to 3.13
 
 .. image:: https://raw.githubusercontent.com/jazzband/wagtailmenus/master/docs/source/_static/images/repeating-item.png


### PR DESCRIPTION
Update the Wagtail, Django, and Python versions mentioned as being tested in the README based on the tox configuration.

This section previously used the greater-than-or-equal sign (`>=`) when the less-than-or-equal sign (`<=`) was intended. Because these symbols are potentially confusing, they have been removed.